### PR TITLE
feat: enable customizable backoffLimit value for init-db

### DIFF
--- a/core-stack-api/CHANGELOG.md
+++ b/core-stack-api/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.5.3 (2020-06-25)
+### 🆕 Features
+* Allow users to define a custom `backoffLimit` for initDBHook Job. (Default value set to 6)
+* Enabling initDBHook and initContainers Jobs by default. 
+
 ## v0.5.2 (2020-05-19)
 
-### 🆕 Features
+### Features
 * Allow exposition of both HTTP & gRPC endpoints in the ingress with more flexibility
 
 ### ⚠ BREAKING CHANGES

--- a/core-stack-api/Chart.yaml
+++ b/core-stack-api/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 description: A Helm chart for Orchestrate API server
 name: core-stack-api
-version: 0.5.2
+version: 0.5.3
 home: https://pegasys.tech/orchestrate/
 icon: https://docs.orchestrate.pegasys.tech/en/stable/logo.svg
 maintainers:

--- a/core-stack-api/templates/init-db-hook.yaml
+++ b/core-stack-api/templates/init-db-hook.yaml
@@ -85,6 +85,7 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
     spec:
       restartPolicy: Never
+      backoffLimit: {{ .Values.initDBHookBackoffLimit }}
       {{- if .Values.imageCredentials }}
       imagePullSecrets:
         - name: {{ include "orchestrate-api.imagePullSecretName" . }}-hook-registry

--- a/core-stack-api/values.yaml
+++ b/core-stack-api/values.yaml
@@ -35,8 +35,9 @@ service:
   metrics:
     port: 8082
 
-initDBHook: false
-initContainers: false
+initDBHook: true
+initDBHookBackoffLimit: 6
+initContainers: true
 
 ingress:
   enabled: false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines -->

## PR Description
- Enable users to define a custom `backoffLimit` for initDBHook Job. (Default value set to 6)
