### PR TITLE
fix(core-stack-api): Fix wrong indentation

### DIFF
--- a/core-stack-api/templates/init-db-hook.yaml
+++ b/core-stack-api/templates/init-db-hook.yaml
@@ -68,7 +68,7 @@ spec:
     metadata:
       name: {{ template "orchestrate-api.fullname" . }}-initdb-pod
       labels:
-        {{- include "orchestrate-api.labels" . | nindent 6 }}
+        {{- include "orchestrate-api.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       {{- if .Values.imageCredentials }}


### PR DESCRIPTION
## PR Description

On fresh install, an error was thrown about unknown fields under `metadata` while deploying Jobs because of badly indented labels. This commits fixes it :)

## Fixed Issue(s)

N/A

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.
